### PR TITLE
Filled in Spectrum-4 support in asic_table.j2

### DIFF
--- a/platform/mellanox/asic_table.j2
+++ b/platform/mellanox/asic_table.j2
@@ -44,6 +44,7 @@
 	'x86_64-nvidia_sn4800_simx-r0':'MELLANOX-SPECTRUM-3',
         'x86_64-nvidia_sn2201-r0':'MELLANOX-SPECTRUM',
         'x86_64-nvidia_sn5600-r0':'MELLANOX-SPECTRUM-4',
+        'x86_64-nvidia_sn5600_simx-r0':'MELLANOX-SPECTRUM-4',
         'vs-platform':'vs'
     }
 %}
@@ -72,6 +73,16 @@
     {
         "ASIC_TABLE:MELLANOX-SPECTRUM-3": {
             "cell_size": "144",
+            "pipeline_latency": "19",
+            "mac_phy_delay": "0.8",
+            "peer_response_time": "3.8"
+        },
+        "OP": "SET"
+    }
+{% elif asic_type == 'MELLANOX-SPECTRUM-4' %}
+    {
+        "ASIC_TABLE:MELLANOX-SPECTRUM-4": {
+            "cell_size": "192",
             "pipeline_latency": "19",
             "mac_phy_delay": "0.8",
             "peer_response_time": "3.8"


### PR DESCRIPTION
Signed-off-by: Raphael Tryster <raphaelt@nvidia.com>


#### Why I did it

Added missing functionality for dynamic buffer calculation in Spectrum-4.

#### How I did it

Added a section of code in asic_table.j2 for Spectrum-4, and added the simx version of SN5600 to the supported list.

#### How to verify it
Manually: buffershow -l should show all ingress/egress lossy/lossless pools, and all fields of profiles should show values.
Automatically: https://github.com/Azure/sonic-mgmt/blob/master/tests/qos/test_buffer.py


#### Which release branch to backport (provide reason below if selected)

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Filled in Spectrum-4 support in asic_table.j2

#### A picture of a cute animal (not mandatory but encouraged)

